### PR TITLE
Upgrade requests to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2018.1.18
 chardet==3.0.4
 idna==2.6
-requests==2.18.4
+requests==2.20.0
 urllib3==1.22


### PR DESCRIPTION
for [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074).